### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -14,7 +14,7 @@ wit-version = "1.0.0"
 icon-path = "slack.png"
 
 [component.build]
-command = "cargo build --release --target wasm32-wasip2 --target-dir ./target && mv ./target/wasm32-wasip2/release/slack_message_component.wasm ./slack.wasm"
+command = "cargo build --release --target wasm32-wasip2 --target-dir ./target && rm -f ./slack.wasm && mv ./target/wasm32-wasip2/release/slack_message_component.wasm ./slack.wasm"
 output_path = "slack.wasm"
 
 [component.settings.webhook_url]


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink